### PR TITLE
Add `exchange_rate` to operation

### DIFF
--- a/cfonb.gemspec
+++ b/cfonb.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name                       = 'cfonb'
-  s.version                    = '0.0.5'
+  s.version                    = '0.0.6'
   s.required_ruby_version      = '>= 3.2.2'
   s.summary                    = 'CFONB parser'
   s.description                = 'An easy to use CFONB format parser'

--- a/lib/cfonb/operation_detail/mmo.rb
+++ b/lib/cfonb/operation_detail/mmo.rb
@@ -14,7 +14,8 @@ module CFONB
         sign = operation.amount <=> 0 # the detail amount is unsigned
 
         operation.original_amount = sign * BigDecimal(line.detail[4..17]) / (10**scale)
-        operation.exchange_rate = BigDecimal(line.detail[-4..-1]) / 1000
+        exchange_rate_value = line.detail[26..29]
+        operation.exchange_rate = BigDecimal(exchange_rate_value) / 1000 if exchange_rate_value
       end
 
       CFONB::OperationDetail.register('MMO', self)

--- a/lib/cfonb/operation_detail/mmo.rb
+++ b/lib/cfonb/operation_detail/mmo.rb
@@ -15,7 +15,10 @@ module CFONB
 
         operation.original_amount = sign * BigDecimal(line.detail[4..17]) / (10**scale)
         exchange_rate_value = line.detail[26..29]
-        operation.exchange_rate = BigDecimal(exchange_rate_value) / 1000 if exchange_rate_value
+        return unless exchange_rate_value
+
+        exchange_rate_scale = line.detail[18]
+        operation.exchange_rate = BigDecimal(exchange_rate_value) / (10**BigDecimal(exchange_rate_scale))
       end
 
       CFONB::OperationDetail.register('MMO', self)

--- a/lib/cfonb/operation_detail/mmo.rb
+++ b/lib/cfonb/operation_detail/mmo.rb
@@ -5,7 +5,7 @@ require 'bigdecimal'
 module CFONB
   module OperationDetail
     class MMO
-      ATTRIBUTES = %i[original_currency original_amount].freeze
+      ATTRIBUTES = %i[original_currency original_amount exchange_rate].freeze
 
       def self.apply(operation, line)
         operation.original_currency = line.detail[0..2]
@@ -14,6 +14,8 @@ module CFONB
         sign = operation.amount <=> 0 # the detail amount is unsigned
 
         operation.original_amount = sign * BigDecimal(line.detail[4..17]) / (10**scale)
+        
+        operation.exchange_rate = BigDecimal(line.detail[-4..-1]) / 1000
       end
 
       CFONB::OperationDetail.register('MMO', self)

--- a/lib/cfonb/operation_detail/mmo.rb
+++ b/lib/cfonb/operation_detail/mmo.rb
@@ -14,7 +14,6 @@ module CFONB
         sign = operation.amount <=> 0 # the detail amount is unsigned
 
         operation.original_amount = sign * BigDecimal(line.detail[4..17]) / (10**scale)
-        
         operation.exchange_rate = BigDecimal(line.detail[-4..-1]) / 1000
       end
 

--- a/spec/cfonb/operation_spec.rb
+++ b/spec/cfonb/operation_spec.rb
@@ -81,16 +81,30 @@ describe CFONB::Operation do
     end
 
     context 'with a MMO detail' do
-      let(:detail) { OpenStruct.new(body: '', detail_code: 'MMO', detail: 'USD000000000008358300000001077') }
+      let(:detail) { OpenStruct.new(body: '', detail_code: 'MMO', detail: 'USD200000000001234') }
 
       it 'Adds the original currency information' do
         operation.merge_detail(detail)
 
         expect(operation).to have_attributes(
           original_currency: 'USD',
-          original_amount: -8358,
-          exchange_rate: 1.077,
+          original_amount: -12.34,
+          exchange_rate: nil,
         )
+      end
+
+      context 'with exchange rate' do
+        let(:detail) { OpenStruct.new(body: '', detail_code: 'MMO', detail: 'USD000000000008358300000001077') }
+
+        it 'Adds the original currency information' do
+          operation.merge_detail(detail)
+
+          expect(operation).to have_attributes(
+            original_currency: 'USD',
+            original_amount: -8358,
+            exchange_rate: 1.077,
+          )
+        end
       end
     end
 

--- a/spec/cfonb/operation_spec.rb
+++ b/spec/cfonb/operation_spec.rb
@@ -81,14 +81,15 @@ describe CFONB::Operation do
     end
 
     context 'with a MMO detail' do
-      let(:detail) { OpenStruct.new(body: '', detail_code: 'MMO', detail: 'USD200000000001234') }
+      let(:detail) { OpenStruct.new(body: '', detail_code: 'MMO', detail: 'USD000000000008358300000001077') }
 
       it 'Adds the original currency information' do
         operation.merge_detail(detail)
 
         expect(operation).to have_attributes(
           original_currency: 'USD',
-          original_amount: -12.34,
+          original_amount: -8358,
+          exchange_rate: 1.077,
         )
       end
     end

--- a/spec/cfonb/parser_spec.rb
+++ b/spec/cfonb/parser_spec.rb
@@ -44,6 +44,7 @@ describe CFONB::Parser do
           value_date: Date.new(2019, 5, 16),
           original_currency: nil,
           original_amount: nil,
+          exchange_rate: nil,
           debtor: 'INTERNET SFR',
         )
 
@@ -62,6 +63,7 @@ describe CFONB::Parser do
           value_date: Date.new(2019, 5, 16),
           original_currency: nil,
           original_amount: nil,
+          exchange_rate: nil,
           debtor: 'ELEC ERDF',
         )
 
@@ -80,6 +82,7 @@ describe CFONB::Parser do
           value_date: Date.new(2019, 5, 15),
           original_currency: nil,
           original_amount: nil,
+          exchange_rate: nil,
         )
 
         expect(statements[1]).to have_attributes(
@@ -110,6 +113,7 @@ describe CFONB::Parser do
           value_date: Date.new(2019, 5, 15),
           original_currency: nil,
           original_amount: nil,
+          exchange_rate: nil,
         )
 
         expect(statements[1].operations[1]).to have_attributes(
@@ -127,6 +131,7 @@ describe CFONB::Parser do
           value_date: Date.new(2019, 5, 15),
           original_currency: nil,
           original_amount: nil,
+          exchange_rate: nil,
         )
 
         expect(statements[1].operations[2]).to have_attributes(
@@ -144,6 +149,7 @@ describe CFONB::Parser do
           value_date: Date.new(2019, 5, 16),
           original_currency: nil,
           original_amount: nil,
+          exchange_rate: nil,
         )
       end
     end
@@ -234,6 +240,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
             debtor: 'INTERNET SFR',
           )
 
@@ -252,6 +259,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
             debtor: 'ELEC ERDF',
           )
 
@@ -270,6 +278,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 15),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
           )
 
           expect(statements[1]).to have_attributes(
@@ -300,6 +309,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 15),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
           )
 
           expect(statements[1].operations[1]).to have_attributes(
@@ -317,6 +327,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 15),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
           )
 
           expect(statements[1].operations[2]).to have_attributes(
@@ -334,6 +345,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
           )
         end
       end
@@ -359,6 +371,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
             debtor: 'ELEC ERDF',
           )
         end
@@ -385,6 +398,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
             debtor: 'ELEC ERDF',
           )
         end
@@ -411,6 +425,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
             debtor: 'ELEC ERDF',
           )
         end
@@ -437,6 +452,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
             debtor: 'ELEC ERDF',
           )
           expect(statements[0].operations[1]).to have_attributes(
@@ -454,6 +470,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
           )
         end
       end
@@ -494,6 +511,7 @@ describe CFONB::Parser do
           value_date: Date.new(2019, 5, 16),
           original_currency: nil,
           original_amount: nil,
+          exchange_rate: nil,
           debtor: 'INTERNET SFR',
         )
       end
@@ -553,6 +571,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
             debtor: 'INTERNET SFR',
           )
         end
@@ -577,6 +596,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
             debtor: 'INTERNET SFR',
           )
         end
@@ -609,6 +629,7 @@ describe CFONB::Parser do
             value_date: Date.new(2019, 5, 16),
             original_currency: nil,
             original_amount: nil,
+            exchange_rate: nil,
             debtor: 'ELEC ERDF',
           )
         end


### PR DESCRIPTION
Some Sobank statements include exchange rate. We need to parse the value and apply to a transaction. 
