### PR TITLE
FIx `exchange_rate` when empty string

### DIFF
--- a/lib/cfonb/operation_detail/mmo.rb
+++ b/lib/cfonb/operation_detail/mmo.rb
@@ -15,7 +15,8 @@ module CFONB
 
         operation.original_amount = sign * BigDecimal(line.detail[4..17]) / (10**scale)
         exchange_rate_value = line.detail[26..29]
-        return if exchange_rate_value.nil? || exchange_rate_value.empty?
+
+        return if exchange_rate_value.nil? || exchange_rate_value.strip.empty?
 
         exchange_rate_scale = line.detail[18]
         operation.exchange_rate = BigDecimal(exchange_rate_value) / (10**BigDecimal(exchange_rate_scale))

--- a/lib/cfonb/operation_detail/mmo.rb
+++ b/lib/cfonb/operation_detail/mmo.rb
@@ -15,7 +15,7 @@ module CFONB
 
         operation.original_amount = sign * BigDecimal(line.detail[4..17]) / (10**scale)
         exchange_rate_value = line.detail[26..29]
-        return unless exchange_rate_value
+        return if exchange_rate_value.nil? || exchange_rate_value.empty?
 
         exchange_rate_scale = line.detail[18]
         operation.exchange_rate = BigDecimal(exchange_rate_value) / (10**BigDecimal(exchange_rate_scale))

--- a/spec/cfonb/operation_spec.rb
+++ b/spec/cfonb/operation_spec.rb
@@ -106,6 +106,20 @@ describe CFONB::Operation do
           )
         end
       end
+
+      context 'when exchange rate is missing' do
+        let(:detail) { OpenStruct.new(body: '', detail_code: 'MMO', detail: 'EUR200000001875625             04') }
+
+        it 'Adds the original currency information' do
+          operation.merge_detail(detail)
+
+          expect(operation).to have_attributes(
+            original_currency: 'EUR',
+            original_amount: -18_756.25,
+            exchange_rate: nil,
+          )
+        end
+      end
     end
 
     context 'with a NPY detail' do


### PR DESCRIPTION
Fix exchange_rate when an empty string