### PR TITLE
Add safe operator

### DIFF
--- a/cfonb.gemspec
+++ b/cfonb.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name                       = 'cfonb'
-  s.version                    = '1.0.0'
+  s.version                    = '1.0.1'
   s.required_ruby_version      = '>= 3.2'
   s.summary                    = 'CFONB parser'
   s.description                = 'An easy to use CFONB format parser'

--- a/lib/cfonb/operation_details/ibe.rb
+++ b/lib/cfonb/operation_details/ibe.rb
@@ -7,7 +7,7 @@ module CFONB
 
       def self.apply(operation, line)
         operation.creditor_identifier = line.detail[0..34].strip
-        operation.creditor_identifier_type = line.detail[35..-1].strip
+        operation.creditor_identifier_type = line.detail[35..-1]&.strip
       end
 
       CFONB::OperationDetails.register('IBE', self)

--- a/lib/cfonb/operation_details/ipy.rb
+++ b/lib/cfonb/operation_details/ipy.rb
@@ -7,7 +7,7 @@ module CFONB
 
       def self.apply(operation, line)
         operation.debtor_identifier = line.detail[0..34].strip
-        operation.debtor_identifier_type = line.detail[35..-1].strip
+        operation.debtor_identifier_type = line.detail[35..-1]&.strip
       end
 
       CFONB::OperationDetails.register('IPY', self)


### PR DESCRIPTION
With the previous implementation there was an assumption that all the IPY and IBE would have the correct foirmatting. With that, we created some errors on parsing that were  due to uncomplete data, for example 'IPY0'. For that we added the safe operator to avoid errors