### PR TITLE
Lg/fix failure when parsing empty details

### DIFF
--- a/cfonb.gemspec
+++ b/cfonb.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name                       = 'cfonb'
-  s.version                    = '1.1.0'
+  s.version                    = '1.1.1'
   s.required_ruby_version      = '>= 3.2'
   s.summary                    = 'CFONB parser'
   s.description                = 'An easy to use CFONB format parser'

--- a/lib/cfonb/operation_details.rb
+++ b/lib/cfonb/operation_details.rb
@@ -15,7 +15,7 @@ module CFONB
     end
 
     def self.for(line)
-      return unless line.respond_to?(:detail_code)
+      return unless line.respond_to?(:detail_code) && line.detail_code != ''
 
       @details[line.detail_code] || Unknown
     end

--- a/lib/cfonb/operation_details/base.rb
+++ b/lib/cfonb/operation_details/base.rb
@@ -7,7 +7,7 @@ module CFONB
         base.singleton_class.prepend(
           Module.new do
             def apply(details, line)
-              code = :"@#{line.detail_code}"
+              code = :"@#{line.detail_code.gsub(' ', '_')}"
               details.instance_variable_set(code, instance_value(details, line, code))
 
               super

--- a/lib/cfonb/operation_details/unknown.rb
+++ b/lib/cfonb/operation_details/unknown.rb
@@ -7,7 +7,7 @@ module CFONB
 
       def self.apply(details, line)
         details.unknown ||= {}
-        code = line.detail_code
+        code = line.detail_code.gsub(' ', '_')
 
         details.unknown[code] =
           if details.unknown[code] && line.detail.is_a?(String)

--- a/spec/cfonb/operation_spec.rb
+++ b/spec/cfonb/operation_spec.rb
@@ -276,8 +276,8 @@ describe CFONB::Operation do
     context 'with an unknown detail' do
       let(:detail) do
         OpenStruct.new(
-          body: '0530004411001871EUR2 0001016255614090823     AAAEUR200000000000740',
-          detail_code: 'AAA',
+          body: '0530004411001871EUR2 0001016255614090823     A AEUR200000000000740',
+          detail_code: 'A A',
           detail: 'EUR200000000000740',
         )
       end
@@ -285,14 +285,25 @@ describe CFONB::Operation do
       it 'adds the detail to the unknown details hash' do
         operation.merge_detail(detail)
 
-        expect(operation.details.unknown).to eq({ 'AAA' => 'EUR200000000000740' })
+        expect(operation.details.unknown).to eq({ 'A_A' => 'EUR200000000000740' })
       end
 
       it 'updates the current details in case of duplicated codes' do
         operation.merge_detail(detail)
         operation.merge_detail(detail)
 
-        expect(operation.details.unknown).to eq({ 'AAA' => "EUR200000000000740\nEUR200000000000740" })
+        expect(operation.details.unknown).to eq({ 'A_A' => "EUR200000000000740\nEUR200000000000740" })
+      end
+
+      it 'does not add any detail if they are empty' do
+        detail = OpenStruct.new(
+          body: '0530004411001871EUR2 0001016255614090823',
+          detail_code: '',
+          detail: 'EUR200000000000740',
+        )
+        operation.merge_detail(detail)
+
+        expect(operation.details.unknown).to be_nil
       end
     end
   end

--- a/spec/cfonb/parser_spec.rb
+++ b/spec/cfonb/parser_spec.rb
@@ -53,6 +53,7 @@ describe CFONB::Parser do
             'AAA' => "INTERNETA AAA\nINTERNETA ABB",
             'BBB' => 'INTERNETE BBB',
             'CCC' => 'INTERNETI CCC',
+            'N_Y' => 'EXAMPLE WITH EMPTY SPACE',
           },
         )
 

--- a/spec/files/example.txt
+++ b/spec/files/example.txt
@@ -10,6 +10,8 @@
 0515589916200000EUR2 98765432100B1160519     AAAINTERNETA ABB                                                           
 0515589916200000EUR2 98765432100B1160519     BBBINTERNETE BBB                                                           
 0515589916200000EUR2 98765432100B1160519     CCCINTERNETI CCC                                                           
+0515589916200000EUR2 98765432100B1160519                                                                                
+0515589916200000EUR2 98765432100B1160519     N YEXAMPLE WITH EMPTY SPACE                                                
 
 0415589916200000EUR2 98765432100B1160519  160519VIR  SEPA DEMONSTRATION          0000000000000000000107}REFERENCE       
 0515589916200000EUR2 98765432100B1160519     NPYELEC ERDF                                                               


### PR DESCRIPTION
When parsing a file coming from sobank we got some sentry errors since the line was empty or the unknwon details had a white space between. Eg. "P A". 

We skip adding the details when this are empty and we add an underscore if there is a whitespace