### PR TITLE
Fix: lines shorter than 120 chars are silently dropped

### DIFF
--- a/lib/cfonb/parser.rb
+++ b/lib/cfonb/parser.rb
@@ -41,11 +41,11 @@ module CFONB
 
     def each_line
       input.each_line do |line|
-        (line.size / 120).times do |index|
-          start = index * 120
-          finish = start + 119
+        line = line.chomp
+        next if line.strip.empty?
 
-          yield line[start..finish]
+        (line.size / 120.0).ceil.times do |index|
+          yield line[index * 120, 120].to_s.ljust(120)
         end
       end
     end

--- a/spec/cfonb/parser_spec.rb
+++ b/spec/cfonb/parser_spec.rb
@@ -192,6 +192,37 @@ describe CFONB::Parser do
       end
     end
 
+    context 'with lines shorter than 120 characters' do
+      # Some banks/intermediaries strip the trailing whitespace of each line,
+      # making them shorter than the 120 characters expected by the standard.
+      let(:input) { File.read('spec/files/example.txt').gsub(/ +$/, '') }
+
+      it 'parses the operations instead of silently dropping them' do
+        expect(statements).to contain_exactly(
+          an_instance_of(CFONB::Statement),
+          an_instance_of(CFONB::Statement),
+        )
+
+        expect(statements[0].operations.size).to eq(3)
+        expect(statements[1].operations.size).to eq(3)
+
+        expect(statements[0].operations[0]).to have_attributes(
+          amount: -32.21,
+          currency: 'EUR',
+          date: Date.new(2019, 5, 16),
+          exoneration_code: '0',
+          interbank_code: 'B1',
+          internal_code: '9162',
+          label: 'PRLV SEPA TEST CABINET',
+          number: 0,
+          rejection_code: '',
+          unavailability_code: '0',
+          value_date: Date.new(2019, 5, 16),
+          reference: '',
+        )
+      end
+    end
+
     context 'with an operation out of a statement' do
       let(:input) { File.read('spec/files/operation_out_of_statement.txt') }
 


### PR DESCRIPTION
## Bug

`CFONB::Parser#each_line` (lib/cfonb/parser.rb) splits fixed-width 120-char
lines using `(line.size / 120).times`. Integer division means any physical
line shorter than 120 characters yields **0 iterations**, so the line is
silently dropped — even in strict mode (`optimistic: false`).

## Real-world impact

Many banks and intermediary tools strip trailing whitespace on line output.
The `reference` field (positions 104-119) is often empty, so affected lines
end up around ~104 characters — well under the 120-char threshold. This
causes operations, or entire statements, to disappear from the parsed
result with no warning or error.

## Fix

- `line.chomp` removes `\n`/`\r\n` (also fixes CRLF files where `\r` leaked
  into the last field of a chunk)
- `next if line.strip.empty?` preserves existing behavior for blank lines
- `(line.size / 120.0).ceil` instead of integer division: a short line now
  yields 1 chunk; a line of `120*n + remainder` yields `n+1` chunks instead
  of losing the trailing fragment
- `.ljust(120)` pads the final chunk so positional slices (amount zone,
  reference field, etc.) return empty strings instead of `nil`. A line
  truncated after the amount zone parses normally (empty reference, same as
  today); a line truncated before it raises a proper `ParserError`
  (handled by `optimistic` mode) instead of a silent drop.

## Tests

- New fixture `spec/files/example_truncated_lines.txt`: `example.txt` with
  trailing whitespace stripped (`sed 's/ *$//'`)
- New context `with lines stripped of trailing whitespace` asserting the
  same statement/operation counts as the valid fixture
- Targeted `.parse_operation` case with a short line truncated after the
  amount zone, confirming `reference: ''` instead of a dropped record
- Full existing suite passes (no regressions)

No existing issue or PR covers this.
